### PR TITLE
Add type definitions for exported object and constants

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -4,10 +4,11 @@
  */
 
 import { request } from './util';
-import {
+import type {
   APIRequest,
   APIResponse,
   AccountServiceRequest,
+  AccountServiceResponse,
   CTokenServiceRequest,
   MarketHistoryServiceRequest,
   GovernanceServiceRequest,
@@ -70,8 +71,8 @@ import {
  * })().catch(console.error);
  * ```
  */
-export function account(options: AccountServiceRequest) : Promise<APIResponse> {
-  return queryApi(options, 'account', '/api/v2/account');
+export function account(options: AccountServiceRequest) : Promise<AccountServiceResponse> {
+  return queryApi(options, 'account', '/api/v2/account') as Promise<AccountServiceResponse>;
 }
 
 /**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,6 @@
+import type { Constants, Decimals } from "./types"
 // Publicly revealed on the parent class
-export const constants = {
+export const constants: Constants = {
   'PriceFeed': 'PriceFeed',
   'Maximillion': 'Maximillion',
   'CompoundLens': 'CompoundLens',
@@ -188,7 +189,7 @@ export const underlyings = ['BAT', 'COMP', 'DAI', 'ETH', 'REP', 'SAI', 'UNI', 'U
 // additional assets supported by the open price feed
 export const opfAssets = ['KNC', 'LINK', 'BTC'];
 
-export const decimals = {
+export const decimals: Decimals = {
   'cBAT': 8,
   'cCOMP': 8,
   'cDAI': 8,

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import * as comp from './comp';
 import * as gov from './gov';
 import * as api from './api';
 import { constants, decimals } from './constants';
-import { Provider, CompoundOptions, CompoundInstance } from './types';
+import type { Provider, CompoundSDK, CompoundOptions, CompoundInstance } from './types';
 
 // Turn off Ethers.js warnings
 ethers.utils.Logger.setLogLevel(ethers.utils.Logger.levels.ERROR);
@@ -49,7 +49,7 @@ ethers.utils.Logger.setLogLevel(ethers.utils.Logger.levels.ERROR);
  *
  * @returns {object} Returns an instance of the Compound.js SDK.
  */
-const CompoundInstance = function(
+const Compound = function(
   provider: Provider | string = 'mainnet', options: CompoundOptions = {}
 ) : CompoundInstance {
   const originalProvider = provider;
@@ -81,15 +81,15 @@ const CompoundInstance = function(
   return instance;
 };
 
-CompoundInstance.eth = eth;
-CompoundInstance.api = api;
-CompoundInstance.util = util;
-CompoundInstance._ethers = ethers;
-CompoundInstance.decimals = decimals;
-CompoundInstance.comp = {
+Compound.eth = eth;
+Compound.api = api;
+Compound.util = util;
+Compound._ethers = ethers;
+Compound.decimals = decimals;
+Compound.comp = {
   getCompBalance: comp.getCompBalance,
   getCompAccrued: comp.getCompAccrued,
 };
+Object.assign(Compound, constants)
 
-const Compound = {...CompoundInstance, ...constants} 
-export = Compound; 
+export = Compound as CompoundSDK; 

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ ethers.utils.Logger.setLogLevel(ethers.utils.Logger.levels.ERROR);
  *
  * @returns {object} Returns an instance of the Compound.js SDK.
  */
-const Compound = function(
+const CompoundInstance = function(
   provider: Provider | string = 'mainnet', options: CompoundOptions = {}
 ) : CompoundInstance {
   const originalProvider = provider;
@@ -81,14 +81,15 @@ const Compound = function(
   return instance;
 };
 
-Compound.eth = eth;
-Compound.api = api;
-Compound.util = util;
-Compound._ethers = ethers;
-Compound.decimals = decimals;
-Compound.comp = {
+CompoundInstance.eth = eth;
+CompoundInstance.api = api;
+CompoundInstance.util = util;
+CompoundInstance._ethers = ethers;
+CompoundInstance.decimals = decimals;
+CompoundInstance.comp = {
   getCompBalance: comp.getCompBalance,
   getCompAccrued: comp.getCompAccrued,
 };
 
-export = {...Compound, ...constants};
+const Compound = {...CompoundInstance, ...constants} 
+export = Compound; 

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,5 @@ Compound.comp = {
   getCompBalance: comp.getCompBalance,
   getCompAccrued: comp.getCompAccrued,
 };
-Object.assign(Compound, constants);
 
-export = Compound;
+export = {...Compound, ...constants};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,8 +9,27 @@ import {
 } from '@ethersproject/abstract-provider';
 import { Deferrable } from '@ethersproject/properties';
 import { BigNumber } from '@ethersproject/bignumber/lib/bignumber';
+import { ethers } from 'ethers';
+import * as eth from '../eth';
+import * as util from '../util';
+import * as comp from '../comp';
+import * as api from '../api';
 
 // =-=-=-=-=-= /src/index.ts =-=-=-=-=-=
+
+export interface CompoundSDK extends Constants {
+  (provider?: string | Provider, options?: CompoundOptions): CompoundInstance;
+  new(provider?: string | Provider, options?: CompoundOptions): CompoundInstance;
+  eth: typeof eth;
+  api: typeof api;
+  util: typeof util;
+  _ethers: typeof ethers;
+  decimals: Decimals;
+  comp: {
+        getCompBalance: typeof comp.getCompBalance;
+        getCompAccrued: typeof comp.getCompAccrued;
+  };
+}
 
 export interface CompoundInstance {
   _networkPromise: Promise<ProviderNetwork>;
@@ -136,6 +155,37 @@ export interface precise {
   value: string;
 }
 
+export interface PaginationSummary {
+  page_number?: number;
+  page_size?: number;
+  total_entries?: number;
+  total_pages?: number;
+}
+
+export interface Account {
+   address?: string;
+   health?: precise;
+   tokens?: AccountCToken[];
+   total_borrow_value_in_eth?: precise;
+   total_collateral_value_in_eth?: precise;
+}
+
+export interface AccountCToken {
+  address?: string;
+  symbol?: string;
+  borrow_balance_underlying?: precise;
+  lifetime_borrow_interest_accrued?: precise;
+  lifetime_supply_interest_accrued?: precise;
+  supply_balance_underlying?: precise;
+}
+
+export enum AccountError {
+  NO_ERROR = "0",
+  INTERNAL_ERROR = "1",
+  INVALID_PAGE_NUMBER = "2",
+  INVALID_PAGE_SIZE = "3"
+}
+
 export interface AccountServiceRequest {
   addresses?: string[] | string;
   min_borrow_value_in_eth?: precise;
@@ -145,6 +195,11 @@ export interface AccountServiceRequest {
   page_size?: number;
   page_number?: number;
   network?: string;
+}
+
+export interface AccountServiceResponse extends APIResponse, AccountServiceRequest {
+  accounts?: Account[];
+  pagination_summary?: PaginationSummary;
 }
 
 export interface CTokenServiceRequest {
@@ -230,4 +285,69 @@ export interface SimpleEthersSigner {
   _signingKey();
   getAddress();
   provider?: SimpleEthersProvider;
+}
+
+
+// =-=-=-=-=-= /src/constants.ts =-=-=-=-=-=
+
+ export interface Constants {
+        PriceFeed: string;
+        Maximillion: string;
+        CompoundLens: string;
+        GovernorAlpha: string;
+        Comptroller: string;
+        Reservoir: string;
+        KNC: string;
+        LINK: string;
+        BTC: string;
+        cBAT: string;
+        cCOMP: string;
+        cDAI: string;
+        cETH: string;
+        cREP: string;
+        cSAI: string;
+        cUNI: string;
+        cUSDC: string;
+        cUSDT: string;
+        cWBTC: string;
+        cZRX: string;
+        BAT: string;
+        COMP: string;
+        DAI: string;
+        ETH: string;
+        REP: string;
+        SAI: string;
+        UNI: string;
+        USDC: string;
+        USDT: string;
+        WBTC: string;
+        ZRX: string;
+}
+
+export interface Decimals {
+  cBAT: number;
+  cCOMP: number;
+  cDAI: number;
+  cETH: number;
+  cREP: number;
+  cSAI: number;
+  cUNI: number;
+  cUSDC: number;
+  cUSDT: number;
+  cWBTC: number;
+  cZRX: number;
+  BAT: number;
+  COMP: number;
+  DAI: number;
+  ETH: number;
+  REP: number;
+  SAI: number;
+  UNI: number;
+  USDC: number;
+  USDT: number;
+  WBTC: number;
+  ZRX: number;
+  KNC: number;
+  LINK: number;
+  BTC: number;
 }


### PR DESCRIPTION
fixes #9 

Was not able to run tests due to error

```
Details:

    /home/humanbeing/Documents/Repos/compound-js/test/eth.test.js:4
    import * as eth from '../src/eth';
    ^^^^^^

    SyntaxError: Cannot use import statement outside a module

      at compileFunction (node:vm:356:18)
      at processTicksAndRejections (node:internal/process/task_queues:93:5)

```