### PR TITLE
Support Ethers.js Provider Objects

### DIFF
--- a/src/eth.ts
+++ b/src/eth.ts
@@ -301,10 +301,17 @@ export function _createProvider(options: CallOptions = {}) : Provider {
   let provider: any = options.provider || (options.network || 'mainnet');
   const isADefaultProvider = !!ethers.providers.getNetwork(provider.toString());
 
+  const isObject = typeof provider === 'object';
+
+  // User passed an ethers.js provider/signer/wallet object
+  if (isObject && (provider._isSigner || provider._isProvider)) {
+    return provider;
+  }
+
   // Create an ethers provider, web3s can sign
   if (isADefaultProvider) {
     provider = ethers.getDefaultProvider(provider);
-  } else if (typeof provider === 'object') {
+  } else if (isObject) {
     provider = new ethers.providers.Web3Provider(provider).getSigner();
   } else {
     provider = new ethers.providers.JsonRpcProvider(provider);

--- a/test/EIP712.test.js
+++ b/test/EIP712.test.js
@@ -4,7 +4,7 @@ const ethers = require('ethers');
 const providerUrl = 'http://localhost:8545';
 
 // Mocked browser `window.ethereum` as unlocked account '0xa0df35...'
-const window = { ethereum: require('./window.ethereum.json') };
+const _window = { ethereum: require('./window.ethereum.json') };
 
 const patchedAddress = '0xa0df350d2637096571f7a701cbc1c5fde30df76a';
 const patchedPrivateKey = '0xb8c1b5c1d81f9475fdf2e334517d29f733bdfa40682207571b12fc1142cbf329';
@@ -58,6 +58,9 @@ module.exports = function suite() {
 
   it('runs EIP712.sign as browser', async function () {
     const provider = new ethers.providers.JsonRpcProvider(providerUrl);
+
+    // make a fresh copy, so our newly defined functions don't break other tests
+    const window = JSON.parse(JSON.stringify(_window));
 
     window.ethereum.send = function (request, callback) {
       const { method, params } = request;

--- a/test/eth.test.js
+++ b/test/eth.test.js
@@ -3,6 +3,9 @@ const ethers = require('ethers');
 const eth = require('../src/eth.ts');
 const providerUrl = 'http://localhost:8545';
 
+// Mocked browser `window.ethereum` as unlocked account '0xa0df35...'
+const _window = { ethereum: require('./window.ethereum.json') };
+
 module.exports = function suite([ publicKeys, privateKeys ]) {
 
   const acc1 = { address: publicKeys[0], privateKey: privateKeys[0] };
@@ -61,11 +64,107 @@ module.exports = function suite([ publicKeys, privateKeys ]) {
 
   });
 
-  it('runs eth._createProvider', async function () {
+  it('runs eth._createProvider with URL string', async function () {
     const provider = await eth._createProvider({ provider: providerUrl });
 
     const expected = 'JsonRpcProvider';
     assert.equal(provider.constructor.name, expected);
+  });
+
+  it('runs eth._createProvider with URL string and private key', async function () {
+    const provider = await eth._createProvider({
+      provider: providerUrl,
+      privateKey: '0xb8c1b5c1d81f9475fdf2e334517d29f733bdfa40682207571b12fc1142cbf329'
+    });
+
+    const expected = 'Wallet';
+    assert.equal(provider.constructor.name, expected);
+  });
+
+  it('runs eth._createProvider with URL string and mnemonic', async function () {
+    const provider = await eth._createProvider({
+      provider: providerUrl,
+      mnemonic: 'clutch captain shoe salt awake harvest setup primary inmate ugly among become'
+    });
+
+    const expected = 'Wallet';
+    assert.equal(provider.constructor.name, expected);
+  });
+
+  it('runs eth._createProvider with fallback', async function () {
+    const provider = await eth._createProvider({ provider: 'mainnet' });
+
+    const expected = 'FallbackProvider';
+    assert.equal(provider.constructor.name, expected);
+  });
+
+  it('runs eth._createProvider with fallback testnet', async function () {
+    const provider = await eth._createProvider({ provider: 'ropsten' });
+
+    const expected = 'FallbackProvider';
+    assert.equal(provider.constructor.name, expected);
+  });
+
+  it('runs eth._createProvider with fallback and private key', async function () {
+    const provider = await eth._createProvider({
+      provider: 'ropsten',
+      privateKey: '0xb8c1b5c1d81f9475fdf2e334517d29f733bdfa40682207571b12fc1142cbf329'
+    });
+
+    const expected = 'Wallet';
+    const expectedChainId = 3;
+    assert.equal(provider.provider._network.chainId, expectedChainId);
+    assert.equal(provider.constructor.name, expected);
+  });
+
+  it('runs eth._createProvider with fallback and private key', async function () {
+    const provider = await eth._createProvider({
+      provider: 'ropsten',
+      mnemonic: 'clutch captain shoe salt awake harvest setup primary inmate ugly among become'
+    });
+
+    const expected = 'Wallet';
+    const expectedChainId = 3;
+    assert.equal(provider.provider._network.chainId, expectedChainId);
+    assert.equal(provider.constructor.name, expected);
+  });
+
+  it('runs eth._createProvider with web window.ethereum object', async function () {
+    // make a fresh copy, so our newly defined functions don't break other tests
+    const window = JSON.parse(JSON.stringify(_window));
+    window.ethereum.send = () => {};
+    window.ethereum.sendAsync = () => {};
+    const provider = await eth._createProvider({ provider: window.ethereum });
+
+    // is changed from 'Web3Provider' to 'JsonRpcSigner' after .getSigner() is used
+    const expected = 'JsonRpcSigner';
+    assert.equal(provider.constructor.name, expected);
+  });
+
+  it('runs eth._createProvider with an Ethers.js JsonRpcProvider', async function () {
+    const ethersProvider = new ethers.providers.JsonRpcProvider(providerUrl);
+    const provider = await eth._createProvider({ provider: ethersProvider });
+
+    const expected = 'JsonRpcProvider';
+    assert.equal(provider.constructor.name, expected);
+  });
+
+  it('runs eth._createProvider with an Ethers.js Web3Provider', async function () {
+    // make a fresh copy, so our newly defined functions don't break other tests
+    const window = JSON.parse(JSON.stringify(_window));
+    window.ethereum.send = () => {};
+    window.ethereum.sendAsync = () => {};
+
+    const ethersProvider = new ethers.providers.Web3Provider(window.ethereum);
+    const ethersSigner = new ethers.providers.Web3Provider(window.ethereum).getSigner();
+    const provider = await eth._createProvider({ provider: ethersProvider });
+    const signer = await eth._createProvider({ provider: ethersSigner });
+
+    // is changed from 'Web3Provider' to 'JsonRpcSigner' after .getSigner() is used
+    const expectedProvider = 'Web3Provider';
+    const expectedSigner = 'JsonRpcSigner';
+    assert.equal(provider.constructor.name, expectedProvider);
+    assert.equal(signer.constructor.name, expectedSigner);
   });
 
   it('runs eth.getProviderNetwork', async function () {

--- a/test/initialize.test.js
+++ b/test/initialize.test.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const Compound = require('../src/index.ts');
 
 // Mocked browser `window.ethereum` as unlocked account '0xa0df35...'
-const window = { ethereum: require('./window.ethereum.json') };
+const _window = { ethereum: require('./window.ethereum.json') };
 
 const providerUrl = 'http://localhost:8545';
 const unlockedPrivateKey = '0xb8c1b5c1d81f9475fdf2e334517d29f733bdfa40682207571b12fc1142cbf329';
@@ -47,6 +47,9 @@ module.exports = function suite() {
   });
 
   it('initializes compound as web3', async function () {
+    // make a fresh copy, so our newly defined functions don't break other tests
+    const window = JSON.parse(JSON.stringify(_window));
+
     window.ethereum.send = function (request, callback) {}
     const compound = new Compound(window.ethereum);
 

--- a/test/window.ethereum.json
+++ b/test/window.ethereum.json
@@ -52,7 +52,5 @@
       null
     ]
   },
-  "autoRefreshOnNetworkChange": true,
-  "send": null,
-  "sendAsync": null
+  "autoRefreshOnNetworkChange": true
 }


### PR DESCRIPTION
Support passing providers to eth.read and eth.trx that were already initialized by ethers.js, instead of only JSON RPC URLs, window.ethereum, and fallback provider names.